### PR TITLE
Add medical inventory tracking

### DIFF
--- a/legacy-software/src/main/java/sae/semestre/six/entities/inventory/InventoryController.java
+++ b/legacy-software/src/main/java/sae/semestre/six/entities/inventory/InventoryController.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.*;
 import sae.semestre.six.entities.email.EmailService;
 import sae.semestre.six.entities.supplierinvoice.SupplierInvoice;
 import sae.semestre.six.entities.supplierinvoice.SupplierInvoiceDetail;
+import sae.semestre.six.entities.pricehistory.PriceHistory;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -31,5 +32,20 @@ public class InventoryController {
     @PostMapping("/reorder")
     public String reorderItems() {
         return inventoryService.reorderItems();
+    }
+
+    @GetMapping
+    public List<Inventory> getInventory() {
+        return inventoryService.getAllItems();
+    }
+
+    @PutMapping("/{itemCode}/price")
+    public String updatePrice(@PathVariable String itemCode, @RequestParam double price) {
+        return inventoryService.updatePrice(itemCode, price);
+    }
+
+    @GetMapping("/{itemCode}/price-history")
+    public List<PriceHistory> getPriceHistory(@PathVariable String itemCode) {
+        return inventoryService.getPriceHistory(itemCode);
     }
 }

--- a/legacy-software/src/main/java/sae/semestre/six/entities/inventory/InventoryService.java
+++ b/legacy-software/src/main/java/sae/semestre/six/entities/inventory/InventoryService.java
@@ -6,6 +6,8 @@ import sae.semestre.six.base.Utils;
 import sae.semestre.six.entities.email.EmailService;
 import sae.semestre.six.entities.supplierinvoice.SupplierInvoice;
 import sae.semestre.six.entities.supplierinvoice.SupplierInvoiceDetail;
+import sae.semestre.six.entities.pricehistory.PriceHistory;
+import sae.semestre.six.entities.pricehistory.PriceHistoryRepository;
 
 import java.io.IOException;
 import java.util.Date;
@@ -17,6 +19,9 @@ public class InventoryService {
 
     @Autowired
     private InventoryRepository inventoryDao;
+
+    @Autowired
+    private PriceHistoryRepository priceHistoryDao;
 
     private final EmailService emailService = EmailService.getInstance();
 
@@ -67,5 +72,30 @@ public class InventoryService {
         }
 
         return "Reorder requests sent for " + lowStockItems.size() + " items";
+    }
+
+    public List<Inventory> getAllItems() {
+        return inventoryDao.findAll();
+    }
+
+    public String updatePrice(String itemCode, double price) {
+        Inventory inventory = inventoryDao.findByItemCode(itemCode);
+        Double oldPrice = inventory.getUnitPrice();
+
+        inventoryDao.updatePrice(itemCode, price);
+
+        PriceHistory history = new PriceHistory();
+        history.setInventory(inventory);
+        history.setOldPrice(oldPrice);
+        history.setNewPrice(price);
+        history.setChangeDate(new Date());
+        priceHistoryDao.save(history);
+
+        return "Price updated";
+    }
+
+    public List<PriceHistory> getPriceHistory(String itemCode) {
+        Inventory inventory = inventoryDao.findByItemCode(itemCode);
+        return priceHistoryDao.findByInventory(inventory);
     }
 }

--- a/legacy-software/src/main/java/sae/semestre/six/entities/pricehistory/PriceHistory.java
+++ b/legacy-software/src/main/java/sae/semestre/six/entities/pricehistory/PriceHistory.java
@@ -25,7 +25,47 @@ public class PriceHistory {
     @Column(name = "change_date")
     @Temporal(TemporalType.TIMESTAMP)
     private Date changeDate = new Date();
-    
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Inventory getInventory() {
+        return inventory;
+    }
+
+    public void setInventory(Inventory inventory) {
+        this.inventory = inventory;
+    }
+
+    public Double getOldPrice() {
+        return oldPrice;
+    }
+
+    public void setOldPrice(Double oldPrice) {
+        this.oldPrice = oldPrice;
+    }
+
+    public Double getNewPrice() {
+        return newPrice;
+    }
+
+    public void setNewPrice(Double newPrice) {
+        this.newPrice = newPrice;
+    }
+
+    public Date getChangeDate() {
+        return changeDate;
+    }
+
+    public void setChangeDate(Date changeDate) {
+        this.changeDate = changeDate;
+    }
+
     
     public Double getPriceIncrease() {
         return newPrice - oldPrice;

--- a/legacy-software/src/main/java/sae/semestre/six/entities/pricehistory/PriceHistoryDao.java
+++ b/legacy-software/src/main/java/sae/semestre/six/entities/pricehistory/PriceHistoryDao.java
@@ -1,0 +1,19 @@
+package sae.semestre.six.entities.pricehistory;
+
+import org.springframework.stereotype.Repository;
+import sae.semestre.six.base.AbstractHibernateDao;
+import sae.semestre.six.entities.inventory.Inventory;
+
+import java.util.List;
+
+@Repository
+public class PriceHistoryDao extends AbstractHibernateDao<PriceHistory, Long> implements PriceHistoryRepository {
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<PriceHistory> findByInventory(Inventory inventory) {
+        return getEntityManager()
+                .createQuery("FROM PriceHistory WHERE inventory = :inventory ORDER BY changeDate DESC")
+                .setParameter("inventory", inventory)
+                .getResultList();
+    }
+}

--- a/legacy-software/src/main/java/sae/semestre/six/entities/pricehistory/PriceHistoryRepository.java
+++ b/legacy-software/src/main/java/sae/semestre/six/entities/pricehistory/PriceHistoryRepository.java
@@ -1,0 +1,10 @@
+package sae.semestre.six.entities.pricehistory;
+
+import sae.semestre.six.base.GenericDao;
+import sae.semestre.six.entities.inventory.Inventory;
+
+import java.util.List;
+
+public interface PriceHistoryRepository extends GenericDao<PriceHistory, Long> {
+    List<PriceHistory> findByInventory(Inventory inventory);
+}

--- a/legacy-software/src/main/java/sae/semestre/six/entities/pricehistory/PriceHistoryService.java
+++ b/legacy-software/src/main/java/sae/semestre/six/entities/pricehistory/PriceHistoryService.java
@@ -1,0 +1,28 @@
+package sae.semestre.six.entities.pricehistory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import sae.semestre.six.entities.inventory.Inventory;
+
+import java.util.Date;
+import java.util.List;
+
+@Service
+public class PriceHistoryService {
+
+    @Autowired
+    private PriceHistoryRepository priceHistoryDao;
+
+    public void recordChange(Inventory inventory, Double oldPrice, Double newPrice) {
+        PriceHistory history = new PriceHistory();
+        history.setInventory(inventory);
+        history.setOldPrice(oldPrice);
+        history.setNewPrice(newPrice);
+        history.setChangeDate(new Date());
+        priceHistoryDao.save(history);
+    }
+
+    public List<PriceHistory> getHistoryForInventory(Inventory inventory) {
+        return priceHistoryDao.findByInventory(inventory);
+    }
+}

--- a/legacy-software/src/test/java/sae/semestre/six/entities/inventory/InventoryControllerTest.java
+++ b/legacy-software/src/test/java/sae/semestre/six/entities/inventory/InventoryControllerTest.java
@@ -1,0 +1,28 @@
+package sae.semestre.six.entities.inventory;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import sae.semestre.six.entities.pricehistory.PriceHistory;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+public class InventoryControllerTest {
+
+    @Autowired
+    private InventoryController inventoryController;
+
+    @Test
+    public void testUpdatePriceCreatesHistory() {
+        List<PriceHistory> before = inventoryController.getPriceHistory("MED001");
+        int initial = before.size();
+
+        inventoryController.updatePrice("MED001", 0.20);
+
+        List<PriceHistory> after = inventoryController.getPriceHistory("MED001");
+        assertTrue(after.size() > initial);
+    }
+}


### PR DESCRIPTION
## Summary
- implement stock tracking endpoints and service methods
- add price history management for inventory items
- expose APIs to update item prices and view history
- test price update and history creation

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684143072fac832aad2c2d4a4441b824