### PR TITLE
Add invoice integrity check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Regulatory Compliance
+
+## RGPD
+- Conseils sur le traitement des données personnelles (notamment les données de santé)
+- Aide au choix de l'hébergement et à la configuration de l'authentification et des autorisations
+- Voir <https://www.cnil.fr/fr/quest-ce-ce-quune-donnee-de-sante>
+
+## Exigences comptables
+- Conformité avec la réglementation anti-fraude à la TVA
+- Les factures finalisées sont inaltérables et archivées avec une empreinte permettant de vérifier leur intégrité

--- a/legacy-software/src/test/java/sae/semestre/six/entities/billing/BillIntegrityTest.java
+++ b/legacy-software/src/test/java/sae/semestre/six/entities/billing/BillIntegrityTest.java
@@ -1,0 +1,25 @@
+package sae.semestre.six.entities.billing;
+
+import org.junit.jupiter.api.Test;
+import sae.semestre.six.entities.patient.Patient;
+import sae.semestre.six.entities.doctor.Doctor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BillIntegrityTest {
+
+    @Test
+    public void testIntegrityHash() {
+        Patient patient = new Patient();
+        patient.setId(1L);
+        Doctor doctor = new Doctor();
+        doctor.setId(1L);
+
+        Bill bill = new Bill(patient, doctor);
+        bill.addDetail("X", 1, 10.0);
+        bill.finalizeBill();
+
+        assertNotNull(bill.getIntegrityHash());
+        assertTrue(bill.verifyIntegrity());
+    }
+}


### PR DESCRIPTION
## Summary
- add compliance README with GDPR links and invoice integrity statement
- store a hash of finalized invoices to prevent tampering
- add test covering invoice integrity logic

## Testing
- `./mvnw -q test` *(fails: wget unable to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684145d4b660832abaac3cc3b29b1a2d