### PR TITLE
Add Swagger configuration to ms-assurance

### DIFF
--- a/ms-assurance/README.md
+++ b/ms-assurance/README.md
@@ -2,6 +2,7 @@
 
 - http://localhost:8888/
 - http://localhost:8888/remboursement/search/remboursementByNomProduitAndNomAssurance
+- http://localhost:8888/swagger-ui/index.html
 
 ## Jeu de données
 ```

--- a/ms-assurance/pom.xml
+++ b/ms-assurance/pom.xml
@@ -42,10 +42,16 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-hateoas</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.springdoc</groupId>
+                        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                        <version>2.5.0</version>
+                </dependency>
 
 		<dependency>
 			<groupId>com.mysql</groupId>

--- a/ms-assurance/src/main/java/sae/semestre/six/ms_assurance/config/SwaggerConfig.java
+++ b/ms-assurance/src/main/java/sae/semestre/six/ms_assurance/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package sae.semestre.six.ms_assurance.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("API Assurance")
+                        .version("1.0")
+                        .description("Documentation de l'API pour le service d'assurance"));
+    }
+}


### PR DESCRIPTION
## Summary
- add Swagger Config to ms-assurance
- include springdoc dependency
- document Swagger UI URL in the README

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68429cdeea84832abeaa07209730addd