### PR TITLE
Add database seed data

### DIFF
--- a/legacy-software/README.md
+++ b/legacy-software/README.md
@@ -4,3 +4,4 @@
 ## Swagger
 - http://localhost:8045/hospital/swagger-ui.html
 
+Un fichier `src/main/resources/data.sql` contient un jeu de données complet pour initialiser toutes les tables de la base.

--- a/legacy-software/src/main/resources/application.properties
+++ b/legacy-software/src/main/resources/application.properties
@@ -39,3 +39,5 @@ hospital.prescription.audit=C:\\hospital\\prescriptions.log
 
 # Treatment default prices as name:price comma separated
 hospital.treatment.defaults=CONSULTATION:50,XRAY:100,BLOOD_TEST:30
+
+spring.sql.init.mode=always

--- a/ms-assurance/src/main/resources/application.properties
+++ b/ms-assurance/src/main/resources/application.properties
@@ -10,3 +10,5 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.hibernate.ddl-auto=update
 
 # spring.datasource.initialize=true
+
+spring.sql.init.mode=always

--- a/ms-assurance/src/main/resources/data.sql
+++ b/ms-assurance/src/main/resources/data.sql
@@ -1,13 +1,4 @@
-# ms-assurance
-
-- http://localhost:8888/
-- http://localhost:8888/remboursement/search/remboursementByNomProduitAndNomAssurance
-- http://localhost:8888/swagger-ui/index.html
-
-## Jeu de données
-```
-INSERT INTO remboursements (nom_produit, nom_assurance, montant_base, taux_remboursement, montant_rembourse)
-VALUES 
+INSERT INTO remboursement (nom_produit, nom_assurance, montant_base, taux_remboursement, montant_rembourse) VALUES
 ('CONSULTATION', 'SECUREPLUS', 30.0, 70.0, 21.0),
 ('CONSULTATION', 'PROTEXIA', 30.0, 65.0, 19.5),
 ('CONSULTATION', 'SANTEVIE', 30.0, 50.0, 15.0),
@@ -38,5 +29,3 @@ VALUES
 ('CHIRURGIE', 'PROTEXIA', 5000.0, 85.0, 4250.0),
 ('MATERNITE', 'SECUREPLUS', 2000.0, 80.0, 1600.0),
 ('MATERNITE', 'SANTEVIE', 2000.0, 75.0, 1500.0);
-```
-Les mêmes instructions d'insertion se trouvent dans `src/main/resources/data.sql` afin que les données soient chargées automatiquement au démarrage du service.


### PR DESCRIPTION
## Summary
- add data.sql with reimbursement dataset for ms-assurance
- ensure Spring loads SQL files by setting `spring.sql.init.mode=always`
- document sample data in both service READMEs

## Testing
- `./mvnw -q test` *(fails: Failed to fetch apache-maven)*

------
https://chatgpt.com/codex/tasks/task_e_68429f6817e4832ab42ecfccdcef154f